### PR TITLE
Use isort to keep imports in sorted order

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install black flake8 isort pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,6 +32,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Run style checks
+      run: |
+        python -m isort --check .
+        python -m black --check .
     - name: Test with pytest
       run: |
         pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,9 @@ license_files = LICENSE
 [flake8]
 max-line-length = 88
 
+[isort]
+profile = black
+order_by_type = False
+
 [mypy-setuptools]
 ignore_missing_imports = True

--- a/simplefractions/__init__.py
+++ b/simplefractions/__init__.py
@@ -40,7 +40,6 @@ import typing
 
 from simplefractions._simplest_in_interval import _simplest_in_interval
 
-
 #: Names to be exported when doing 'from simplefractions import *'.
 __all__ = ["simplest_from_float", "simplest_in_interval"]
 

--- a/simplefractions/test/test_simplefractions.py
+++ b/simplefractions/test/test_simplefractions.py
@@ -15,8 +15,8 @@
 import fractions
 import math
 import random
-import unittest
 import sys
+import unittest
 
 from simplefractions import simplest_from_float, simplest_in_interval
 


### PR DESCRIPTION
This PR:

- Applies `isort` to sort imports
- Adds configuration for `isort`, compatible with `black`
- Adds `isort` and `black` checks to GitHub Actions test workflow