### PR TITLE
Do a full clone in release workflow

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
This PR ensures that in the release workflow we do a full clone, so that `setuptools_scm` has enough information to compute a version number.

We don't strictly need this if we only ever expect to be making releases from a tagged commit (which seems likely), but the failure mode if this is left out is that we compute a wrong version. So it seems better to include it. If some future version of `setuptools_scm` makes this an error, it should be safe to remove this.

See https://github.com/pypa/setuptools_scm/issues/480 for more discussion.