### PR TITLE
Don't mention license twice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,7 @@ name = 'simplefractions'
 description = 'Find the simplest fraction for a given float or interval'
 readme = 'README.md'
 requires-python = '>=3.6'
-license = {file = 'LICENSE'}
-authors = [
-    {name = 'Mark Dickinson', email = 'dickinsm@gmail.com'}
-]
+authors = [{name = 'Mark Dickinson', email = 'dickinsm@gmail.com'}]
 keywords = ['fractions', 'continued fractions', 'approximation']
 classifiers = [
     'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
The use of `license = {file = 'LICENSE'}` results in significant ugliness in the sidebar on PyPI. We don't appear to need it, since the license is already specified in the trove classifiers. This PR removes that entry from the `pyproject.toml` (and also does a drive-by cleanup of the `authors` field).