### PR TITLE
Add py.typed, run type checks as part of GitHub Actions

### DIFF
--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -25,6 +25,9 @@ jobs:
       run: python -m pip install -r requirements/test.txt
     - name: Check types with mypy
       run: python -m mypy .
+      # Skip type check for Python 3.14, since it's hitting an argparse-related
+      # issue in mypy: https://github.com/python/mypy/pull/19020
+      if: matrix.python-version != '3.14'
     - name: Test with pytest
       run: python -m pytest
 
@@ -46,4 +49,3 @@ jobs:
         python -m flake8 .
         python -m isort --check --diff .
         python -m black --check --diff .
-        python -m mypy --strict .

--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -22,6 +22,8 @@ jobs:
         cache-dependency-path: 'requirements/test.txt'
     - name: Install dependencies
       run: python -m pip install -r requirements/test.txt
+    - name: Check types with mypy
+      run: python -m mypy .
     - name: Test with pytest
       run: python -m pytest
 

--- a/proofs/fraction_to_float.py
+++ b/proofs/fraction_to_float.py
@@ -1,7 +1,9 @@
+import typing
+
 from math import gcd
 
 
-def find_cd(a: int, b: int) -> list[tuple[int, int]]:
+def find_cd(a: int, b: int) -> typing.List[typing.Tuple[int, int]]:
     """
     Given a positive fraction a/b (expressed in lowest terms), find both
     fractions c/d which are simpler than a/b and which satisfy |ad - bc| = 1.

--- a/proofs/fraction_to_float.py
+++ b/proofs/fraction_to_float.py
@@ -1,5 +1,4 @@
 import typing
-
 from math import gcd
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,5 +27,8 @@ target-version = ['py36']
 profile = 'black'
 order_by_type = 'False'
 
+[tool.mypy]
+strict = true
+
 [tool.setuptools_scm]
 version_scheme = 'release-branch-semver'

--- a/requirements/style.txt
+++ b/requirements/style.txt
@@ -1,4 +1,3 @@
 black
 flake8
 isort
-mypy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,1 +1,2 @@
+mypy
 pytest


### PR DESCRIPTION
This PR:

- adds the missing `py.typed` marker file that indicates to consumers that the code has usable type hints
- moves type checks to the test job of `on-commit` GitHub Actions workflow, instead of the style job. (Those type checks are Python-version dependent, and we want our type hints to be valid for all supported Python versions.)
- fixes type hints to be Python 3.8-compatible on the `fraction_to_float.py` script

Note: we're hitting a (known, fixed in main) issue with mypy and Python 3.14, so we skip the type check on Python 3.14 for now. xref: https://github.com/python/mypy/pull/19020