### PR TITLE
Adjust Python versions

### DIFF
--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.8', '3.10', '3.11-dev', 'pypy3.9']
+        python-version: ['3.8', '3.10', '3.12', '3.13', '3.14', 'pypy3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -20,6 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
         cache-dependency-path: 'requirements/test.txt'
+        allow-prereleases: true
     - name: Install dependencies
       run: python -m pip install -r requirements/test.txt
     - name: Test with pytest
@@ -30,10 +31,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.13
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.13'
         cache: 'pip'
         cache-dependency-path: 'requirements/style.txt'
     - name: Install dependencies

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -13,10 +13,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python 3.10
+    - name: Set up Python 3.13
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.13'
         cache: 'pip'
         cache-dependency-path: 'requirements/publish.txt'
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'setuptools.build_meta'
 name = 'simplefractions'
 description = 'Find the simplest fraction for a given float or interval'
 readme = 'README.md'
-requires-python = '>=3.6'
+requires-python = '>=3.8'
 authors = [{name = 'Mark Dickinson', email = 'dickinsm@gmail.com'}]
 keywords = ['fractions', 'continued fractions', 'approximation']
 classifiers = [
@@ -21,7 +21,7 @@ dynamic = ['version']
 source = 'https://github.com/mdickinson/simplefractions'
 
 [tool.black]
-target-version = ['py36']
+target-version = ['py38']
 
 [tool.isort]
 profile = 'black'


### PR DESCRIPTION
This PR updates the Python versions:

- the main package now requires Python >= 3.8
- the test workflow runs on a selection of versions from 3.8 through to 3.14
- the style and package upload jobs use Python 3.13

The test workflow update was needed because Python 3.6 and Python 3.7 are no longer available on the GitHub Actions runners.