### PR TITLE
Replace black, isort and flake8 with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 88

--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -38,5 +38,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install ruff and apply 'ruff check'
       uses: astral-sh/ruff-action@v3
+      with:
+        version: 'latest'
     - name: Check for formatting changes
       run: ruff format --check --diff

--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -36,16 +36,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.13'
-        cache: 'pip'
-        cache-dependency-path: 'requirements/style.txt'
-    - name: Install dependencies
-      run: python -m pip install -r requirements/style.txt
-    - name: Run style checks
-      run: |
-        python -m flake8 .
-        python -m isort --check --diff .
-        python -m black --check --diff .
+    - name: Install ruff and apply 'ruff check'
+      uses: astral-sh/ruff-action@v3
+    - name: Check for formatting changes
+      run: ruff format --check --diff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,11 @@ dynamic = ['version']
 [project.urls]
 source = 'https://github.com/mdickinson/simplefractions'
 
-[tool.black]
-target-version = ['py38']
-
-[tool.isort]
-profile = 'black'
-order_by_type = 'False'
-
 [tool.mypy]
 strict = true
+
+[tool.ruff.lint]
+extend-select = ["I"]
 
 [tool.setuptools_scm]
 version_scheme = 'release-branch-semver'

--- a/requirements/style.txt
+++ b/requirements/style.txt
@@ -1,3 +1,0 @@
-black
-flake8
-isort


### PR DESCRIPTION
This PR switches to ruff for formatting and linting, replacing use of black, isort and flake8.