### PR TITLE
Minor workflow updates

### DIFF
--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.12', '3.13', '3.14', '3.14t', 'pypy3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', 'pypy3.11']
 
     steps:
     - uses: actions/checkout@v5
     - uses: astral-sh/setup-uv@v6
       with:
-        version: "0.9.7"
+        version: "0.9.9"
         python-version: ${{ matrix.python-version }}
     - name: Set up environment
       run: uv sync --locked

--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -1,5 +1,3 @@
-# Run tests and style checks on each commit to an open pull request.
-
 name: on-commit
 
 on: [pull_request, workflow_dispatch]
@@ -7,7 +5,6 @@ on: [pull_request, workflow_dispatch]
 jobs:
   test:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         python-version: ['3.10', '3.12', '3.13', '3.14', '3.14t', 'pypy3.11']
@@ -17,10 +14,13 @@ jobs:
     - uses: astral-sh/setup-uv@v6
       with:
         version: "0.9.7"
+        python-version: ${{ matrix.python-version }}
+    - name: Set up environment
+      run: uv sync --locked
     - name: Check types with mypy
-      run: uv run --python ${{ matrix.python-version }} mypy
+      run: uv run mypy
     - name: Test with pytest
-      run: uv run --python ${{ matrix.python-version }} pytest
+      run: uv run pytest
 
   style:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: astral-sh/setup-uv@v6
       with:
-        version: "0.9.7"
+        version: "0.9.9"
     - name: Build package
       run: uv build
     - name: Publish package

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build-and-upload:
-    name: Build and upload release to PyPI
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -15,8 +14,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
     - uses: astral-sh/setup-uv@v6
       with:
         version: "0.9.7"

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 __pycache__/
 
 # Coverage database
-.coverage
+/.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.9.7,<0.10.0"]
+requires = ["uv_build>=0.9.9,<0.10.0"]
 build-backend = "uv_build"
 
 [project]
@@ -8,8 +8,12 @@ version = "1.4.0"
 description = 'Find the simplest fraction for a given float or interval'
 readme = 'README.md'
 requires-python = '>=3.10'
-authors = [{name = 'Mark Dickinson', email = 'dickinsm@gmail.com'}]
-keywords = ['fractions', 'continued fractions', 'approximation']
+authors = [{ name = 'Mark Dickinson', email = 'dickinsm@gmail.com' }]
+keywords = [
+    'fractions',
+    'continued fractions',
+    'approximation',
+]
 classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Operating System :: OS Independent',
@@ -38,9 +42,6 @@ strict = true
 
 [tool.pytest.ini_options]
 addopts = ["--pyargs", "--import-mode=importlib"]
-
-[tool.ruff]
-target-version = "py310"
 
 [tool.ruff.lint]
 extend-select = ["I", "UP", "W"]  # isort, pyupgrade, pycodestyle warnings


### PR DESCRIPTION
- add Python 3.11 to the test matrix, for completeness
- bump uv and uv_build versions
- refine `.gitignore`
- remove unnecessary ruff target-version - it should be inferred from the `requires-python` setting